### PR TITLE
Implement pick

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "purescript-typelevel-prelude": "^3.0.0",
     "purescript-record": "^1.0.0",
+    "purescript-functions": "^4.0.0",
     "purescript-lists": "^5.0.0"
   },
   "devDependencies": {

--- a/src/Record/Extra.js
+++ b/src/Record/Extra.js
@@ -1,0 +1,9 @@
+"use strict";
+
+exports.pickFn = function(ks, r) {
+  var copy = {};
+  for(var i = 0; i < ks.length; i++) {
+      copy[ks[i]] = r[ks[i]];
+  }
+  return copy;
+};

--- a/src/Record/Extra.purs
+++ b/src/Record/Extra.purs
@@ -134,9 +134,9 @@ pick :: forall a r b l.
   => Keys l
   => Record a
   -> Record b
-pick = runFn2 pickFn $ (ks :: Array String)
+pick = runFn2 pickFn ks
   where
-    ks = (fromFoldable $ keys (RProxy :: RProxy b))
+    ks = fromFoldable $ keys (RProxy :: RProxy b)
 
 slistKeys :: forall g tuples rl
    . SListToRowList tuples rl

--- a/src/Record/Extra.purs
+++ b/src/Record/Extra.purs
@@ -2,6 +2,8 @@ module Record.Extra where
 
 import Prelude
 
+import Data.Array (fromFoldable)
+import Data.Function.Uncurried (Fn2, runFn2)
 import Data.List (List, (:))
 import Data.Tuple (Tuple(..))
 import Prim.Row as Row
@@ -9,7 +11,7 @@ import Prim.RowList as RL
 import Record (get) as R
 import Record.Builder (Builder)
 import Record.Builder as Builder
-import Type.Prelude (class IsSymbol, RLProxy(RLProxy), SProxy(SProxy), reflectSymbol)
+import Type.Prelude (class IsSymbol, RProxy(RProxy), RLProxy(RLProxy), SProxy(SProxy), reflectSymbol)
 
 mapRecord :: forall row xs a b row'
    . RL.RowToList row xs
@@ -123,6 +125,18 @@ keys :: forall g row rl
   => g row -- this will work for any type with the row as a param!
   -> List String
 keys _ = keysImpl (RLProxy :: RLProxy rl)
+
+foreign import pickFn :: forall r1 r2. Fn2 (Array String) (Record r1) (Record r2)
+
+pick :: forall a r b l.
+     Row.Union b r a
+  => RL.RowToList b l
+  => Keys l
+  => Record a
+  -> Record b
+pick = runFn2 pickFn $ (ks :: Array String)
+  where
+    ks = (fromFoldable $ keys (RProxy :: RProxy b))
 
 slistKeys :: forall g tuples rl
    . SListToRowList tuples rl

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,7 +6,8 @@ import Data.List (List(Nil), (:))
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
-import Record.Extra (type (:::), SLProxy(..), SNil, compareRecord, keys, mapRecord, sequenceRecord, slistKeys, zipRecord)
+import Record (merge)
+import Record.Extra (type (:::), SLProxy(..), SNil, compareRecord, keys, pick, mapRecord, sequenceRecord, slistKeys, zipRecord)
 import Test.Unit (failure, success, suite, test)
 import Test.Unit.Assert (equal, shouldEqual)
 import Test.Unit.Main (runTest)
@@ -33,6 +34,14 @@ main = runTest do
     test "keys" do
       let keyed = keys { a: 1, b: 2 }
       equal ("a" : "b" : Nil) keyed
+
+    test "pick" do
+      let r1 = (pick {a: 1, b: 2, c: 3} :: Record (a :: Int, b :: Int))
+      equal r1 {a: 1, b: 2}
+      let r2 = {a: 4, b: 5, c: 6}
+      -- Note: merge copies all runtime keys of an object
+      --       which is why we can't just use unsafeCoerce
+      equal (r1 `merge` r2) {a: 1, b: 2, c: 6}
 
     test "slistKeys" do
       let slistKeyed = slistKeys $ SLProxy :: SLProxy ("a" ::: "b" ::: "c" ::: SNil)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -37,11 +37,15 @@ main = runTest do
 
     test "pick" do
       let r1 = (pick {a: 1, b: 2, c: 3} :: Record (a :: Int, b :: Int))
-      equal r1 {a: 1, b: 2}
+      r1 `shouldEqual` {a: 1, b: 2}
       let r2 = {a: 4, b: 5, c: 6}
       -- Note: merge copies all runtime keys of an object
       --       which is why we can't just use unsafeCoerce
-      equal (r1 `merge` r2) {a: 1, b: 2, c: 6}
+      (r1 `merge` r2) `shouldEqual` {a: 1, b: 2, c: 6}
+      pick {a: 1, b: 2, c: 3} `shouldEqual` {}
+      pick {a: 1, b: 2, c: 3} `shouldEqual` {a: 1}
+      pick {a: 1, b: 2, c: 3} `shouldEqual` {a: 1, b: 2}
+      pick {a: 1, b: 2, c: 3} `shouldEqual` {a: 1, b: 2, c: 3}
 
     test "slistKeys" do
       let slistKeyed = slistKeys $ SLProxy :: SLProxy ("a" ::: "b" ::: "c" ::: SNil)


### PR DESCRIPTION
I didn't realise this had already been implemented (PR #15) until after I'd written it 😅 - I don't want to step on anyones toes! I hope that `pick` can finally make it into the library!

This is actually almost identical to @coot's implementation, although it uses the existing `Keys`/`keys` functionality from this package.