### PR TITLE
Relax typelevel-prelude upper bound

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-typelevel-prelude": "^4.0.0",
+    "purescript-typelevel-prelude": ">=4.0.0 <6.0.0",
     "purescript-record": "^2.0.0",
     "purescript-functions": "^4.0.0",
     "purescript-lists": "^5.0.0",


### PR DESCRIPTION
This allows this library to be used with people using 0.13.x in bower projects, without necessitating a breaking release.